### PR TITLE
Fix error when opening the Node infos dialog (Edit->Node infos)

### DIFF
--- a/objdictgen/commondialogs.py
+++ b/objdictgen/commondialogs.py
@@ -674,7 +674,7 @@ class NodeInfosDialog(wx.Dialog):
 
     def _init_sizers(self):
         self.flexGridSizer1 = wx.FlexGridSizer(cols=1, hgap=0, rows=2, vgap=10)
-        self.MainSizer = wx.FlexGridSizer(cols=1, hgap=0, rows=8, vgap=5)
+        self.MainSizer = wx.FlexGridSizer(cols=1, hgap=0, rows=10, vgap=5)
         
         self._init_coll_flexGridSizer1_Items(self.flexGridSizer1)
         self._init_coll_flexGridSizer1_Growables(self.flexGridSizer1)


### PR DESCRIPTION
Fixed an error when opening the Node infos dialog by changing the row count of the dialog layout.

This was the error:

![objdictedit_error](https://user-images.githubusercontent.com/39401715/43944973-127c9722-9c81-11e8-9ac8-bbd1460423fe.png)
